### PR TITLE
READMEにデータベース設計を記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -39,12 +39,13 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, unique: true|
+|name|string|null: false, unique: true, index: true|
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 
 ### Association
-- belongs_to :message
+- has_many :messages
+- has_many :members
 - has_many :groups, through: :members
 
 
@@ -56,7 +57,8 @@ Things you may want to cover:
 
 
 ### Association
-- belongs_to :message
+- has_many :messages
+- has_many :members
 - has_many :users, through: :members
 
 
@@ -65,13 +67,14 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
-- has_many :users
-- has_many :groups
+- belongs_to :user
+- belongs_to :group
+
 
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,56 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## membersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|password|string|null: false, unique: true|
+
+### Association
+- belongs_to :message
+- has_many :groups, through: :members
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+
+
+### Association
+- belongs_to :message
+- has_many :users, through: :members
+
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :users
+- has_many :groups
+
+


### PR DESCRIPTION
#What
READMEに、マークダウン方式で記述。
messages,users,groups,members各テーブルにカラム名、カラムの型、カラムのオプション、アソシエーションを記述

#Why
ソフトウェアの仕様、規格、インストール方法などを文書化したものにDB設計を記載することで分かりやすくするため